### PR TITLE
Update version to 0.0.70 and enhance energy sensor configuration options

### DIFF
--- a/custom_components/energy_sensor_generator/const.py
+++ b/custom_components/energy_sensor_generator/const.py
@@ -8,3 +8,5 @@ CONF_DEBUG_LOGGING = "debug_logging"
 CONF_USE_STATISTICAL = "use_statistical_calculation"
 # Removed redundant point sampling options - simplified to just use statistical calculation toggle 
 CONF_CREATE_SYNTHETIC_GRID_TOTAL = "create_synthetic_grid_total"
+CONF_FORCE_STATISTICAL_ONLY = "force_statistical_only"
+CONF_STAT_LOOKBACK_MINUTES = "stat_initial_lookback_minutes"

--- a/custom_components/energy_sensor_generator/manifest.json
+++ b/custom_components/energy_sensor_generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "energy_sensor_generator",
   "name": "Energy Sensor Generator",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "documentation": "https://github.com/Vortitron/energy-sensor-generator",
   "requirements": [],
   "codeowners": ["@Vortitron"],

--- a/custom_components/energy_sensor_generator/options_flow.py
+++ b/custom_components/energy_sensor_generator/options_flow.py
@@ -18,7 +18,9 @@ from .const import (
 	DOMAIN, 
 	CONF_DEBUG_LOGGING, 
 	CONF_USE_STATISTICAL, 
-	CONF_CREATE_SYNTHETIC_GRID_TOTAL
+	CONF_CREATE_SYNTHETIC_GRID_TOTAL,
+	CONF_FORCE_STATISTICAL_ONLY,
+	CONF_STAT_LOOKBACK_MINUTES
 )
 from .__init__ import detect_power_sensors  # Import the detect function
 
@@ -66,6 +68,8 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 		debug_logging = defaults.get(CONF_DEBUG_LOGGING, False)
 		use_statistical = defaults.get(CONF_USE_STATISTICAL, True)
 		synthetic_grid_total = defaults.get(CONF_CREATE_SYNTHETIC_GRID_TOTAL, False)
+		force_statistical_only = defaults.get(CONF_FORCE_STATISTICAL_ONLY, False)
+		stat_lookback = defaults.get(CONF_STAT_LOOKBACK_MINUTES, 60)
 		
 		# Merge auto-detected and previously selected sensors for the selection list
 		all_power_sensors = {}
@@ -174,6 +178,8 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 			debug_logging = user_input.get(CONF_DEBUG_LOGGING, False)
 			use_statistical = user_input.get(CONF_USE_STATISTICAL, True)
 			synthetic_grid_total = user_input.get(CONF_CREATE_SYNTHETIC_GRID_TOTAL, False)
+			force_statistical_only = user_input.get(CONF_FORCE_STATISTICAL_ONLY, False)
+			stat_lookback = user_input.get(CONF_STAT_LOOKBACK_MINUTES, 60)
 			
 			if not self._errors:
 				# Create the configuration entry first
@@ -188,7 +194,9 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 						"sample_interval": sample_interval,
 						CONF_DEBUG_LOGGING: debug_logging,
 						CONF_USE_STATISTICAL: use_statistical,
-						CONF_CREATE_SYNTHETIC_GRID_TOTAL: synthetic_grid_total
+						CONF_CREATE_SYNTHETIC_GRID_TOTAL: synthetic_grid_total,
+						CONF_FORCE_STATISTICAL_ONLY: force_statistical_only,
+						CONF_STAT_LOOKBACK_MINUTES: stat_lookback
 					}
 				)
 
@@ -269,6 +277,8 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 		debug_logging = defaults.get(CONF_DEBUG_LOGGING, False)
 		use_statistical = defaults.get(CONF_USE_STATISTICAL, True)
 		synthetic_grid_total = defaults.get(CONF_CREATE_SYNTHETIC_GRID_TOTAL, False)
+		force_statistical_only = defaults.get(CONF_FORCE_STATISTICAL_ONLY, False)
+		stat_lookback = defaults.get(CONF_STAT_LOOKBACK_MINUTES, 60)
 		
 		if user_input is not None:
 			# Update defaults with advanced settings
@@ -297,6 +307,8 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 			sample_interval = user_input.get("sample_interval", 60)
 			debug_logging = user_input.get(CONF_DEBUG_LOGGING, False)
 			use_statistical = user_input.get(CONF_USE_STATISTICAL, True)
+			force_statistical_only = user_input.get(CONF_FORCE_STATISTICAL_ONLY, False)
+			stat_lookback = user_input.get(CONF_STAT_LOOKBACK_MINUTES, 60)
 			
 			# Create the configuration entry
 			result = self.async_create_entry(
@@ -310,7 +322,9 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 					"sample_interval": sample_interval,
 					CONF_DEBUG_LOGGING: debug_logging,
 					CONF_USE_STATISTICAL: use_statistical,
-					CONF_CREATE_SYNTHETIC_GRID_TOTAL: synthetic_grid_total
+					CONF_CREATE_SYNTHETIC_GRID_TOTAL: synthetic_grid_total,
+					CONF_FORCE_STATISTICAL_ONLY: force_statistical_only,
+					CONF_STAT_LOOKBACK_MINUTES: stat_lookback
 				}
 			)
 			
@@ -332,7 +346,17 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 		)
 		schema[vol.Optional(CONF_DEBUG_LOGGING, default=debug_logging)] = BooleanSelector()
 		schema[vol.Optional(CONF_USE_STATISTICAL, default=use_statistical)] = BooleanSelector()
-				# Option to create synthetic grid total
+		schema[vol.Optional(CONF_FORCE_STATISTICAL_ONLY, default=force_statistical_only)] = BooleanSelector()
+		schema[vol.Optional(CONF_STAT_LOOKBACK_MINUTES, default=stat_lookback)] = NumberSelector(
+			NumberSelectorConfig(
+				min=5,
+				max=120,
+				step=5,
+				unit_of_measurement="minutes",
+				mode=NumberSelectorMode.SLIDER
+			)
+		)
+		# Option to create synthetic grid total
 		schema[vol.Optional(CONF_CREATE_SYNTHETIC_GRID_TOTAL, default=synthetic_grid_total)] = BooleanSelector()
 		
 		return self.async_show_form(
@@ -364,19 +388,29 @@ class EnergySensorGeneratorOptionsFlow(config_entries.OptionsFlow):
 			
 			_LOGGER.info("Energy sensors generated successfully after configuration update")
 			
-			# Send a persistent notification to the user
-			self.hass.components.persistent_notification.async_create(
-				message="Energy sensors have been created automatically based on your new configuration. Check the Entities page to see your new sensors.",
-				title="Energy Sensor Generator",
-				notification_id="energy_sensor_generator_created"
+			# Send a persistent notification to the user (use services API; components attribute is no longer available)
+			await self.hass.services.async_call(
+				"persistent_notification",
+				"create",
+				{
+					"message": "Energy sensors have been created automatically based on your new configuration. Check the Entities page to see your new sensors.",
+					"title": "Energy Sensor Generator",
+					"notification_id": "energy_sensor_generator_created"
+				},
+				blocking=False
 			)
 			
 		except Exception as e:
 			_LOGGER.error(f"Failed to auto-generate sensors after configuration: {e}")
 			
 			# Send error notification to user
-			self.hass.components.persistent_notification.async_create(
-				message=f"Failed to automatically create energy sensors: {str(e)}. You may need to manually reload the integration.",
-				title="Energy Sensor Generator - Error",
-				notification_id="energy_sensor_generator_error"
-		)
+			await self.hass.services.async_call(
+				"persistent_notification",
+				"create",
+				{
+					"message": f"Failed to automatically create energy sensors: {str(e)}. You may need to manually reload the integration.",
+					"title": "Energy Sensor Generator - Error",
+					"notification_id": "energy_sensor_generator_error"
+				},
+				blocking=False
+			)

--- a/custom_components/energy_sensor_generator/sensor.py
+++ b/custom_components/energy_sensor_generator/sensor.py
@@ -29,7 +29,9 @@ from .utils import StorageManager
 from .const import (
 	DOMAIN, 
 	CONF_DEBUG_LOGGING, 
-	CONF_USE_STATISTICAL
+	CONF_USE_STATISTICAL,
+	CONF_FORCE_STATISTICAL_ONLY,
+	CONF_STAT_LOOKBACK_MINUTES
 )
 import time
 
@@ -79,6 +81,8 @@ def _get_config_options(hass: HomeAssistant) -> dict:
 	"""Get configuration options from the integration."""
 	default_options = {
 		CONF_USE_STATISTICAL: True,  # Use statistical calculation by default
+		CONF_FORCE_STATISTICAL_ONLY: False,
+		CONF_STAT_LOOKBACK_MINUTES: 60,
 	}
 	
 	# Check all hass.data domain entries safely (some keys are floats used for throttling)
@@ -856,18 +860,20 @@ class EnergySensor(SensorEntity, RestoreEntity):
             statistical_data = None
             if use_statistical and STATISTICS_AVAILABLE:
                 try:
-                    # For statistical calculation, always use a fixed lookback window for consistency and reliability
-                    # This approach avoids double counting by tracking the last time we performed statistical calculation
+                    # For statistical calculation, use a configurable initial lookback window.
+                    # Then, when we have a last statistical timestamp, switch to incremental windows.
+                    config_options = _get_config_options(self.hass)
+                    initial_minutes = max(5, int(config_options.get(CONF_STAT_LOOKBACK_MINUTES, 15)))
                     if hasattr(self, '_last_statistical_calculation') and self._last_statistical_calculation:
                         # Calculate energy only since the last statistical calculation
                         stat_start_time = self._last_statistical_calculation
                         stat_end_time = now
                         _debug_log(self.hass, f"Using incremental statistical time range: {stat_start_time} to {stat_end_time}")
                     else:
-                        # First time or no previous statistical calculation - use 15 minute window
-                        stat_start_time = now - timedelta(minutes=15)
+                        # First time or no previous statistical calculation - use configured window
+                        stat_start_time = now - timedelta(minutes=initial_minutes)
                         stat_end_time = now
-                        _debug_log(self.hass, f"Initial statistical calculation - using 15 minute window: {stat_start_time} to {stat_end_time}")
+                        _debug_log(self.hass, f"Initial statistical calculation - using {initial_minutes} minute window: {stat_start_time} to {stat_end_time}")
                     # Get statistical data using LEFT Riemann sum (like HA's integration sensor)
                     statistical_data = await self._get_statistical_power_data(stat_start_time, stat_end_time)
                     # If successful, update the last statistical calculation time
@@ -906,7 +912,7 @@ class EnergySensor(SensorEntity, RestoreEntity):
                     _LOGGER.warning(f"CONFIGURATION ERROR: {self._attr_name} is monitoring an ENERGY sensor ({self._source_sensor}) instead of a POWER sensor! This will not work correctly. Please reconfigure to monitor a power sensor with unit 'W' or 'kW'.")
                     return
             
-            # Use statistical data if available, otherwise fall back to trapezoidal rule
+            # Use statistical data if available, otherwise optionally fall back to point sampling
             if statistical_data is not None and isinstance(statistical_data, (int, float)) and statistical_data > 0:
                 old_state = self._state
                 self._state += statistical_data
@@ -919,6 +925,15 @@ class EnergySensor(SensorEntity, RestoreEntity):
                     self._first_calculation_logged = True
                 _debug_log(self.hass, f"Statistical energy calculation: {self._attr_name} | Energy added: {statistical_data:.8f}kWh | Total: {self._state:.4f}kWh | Current power: {power:.2f}{unit_display}")
             else:
+                # Determine if fallback is permitted
+                if _get_config_options(self.hass).get(CONF_FORCE_STATISTICAL_ONLY, False):
+                    _debug_log(self.hass, f"Statistical-only mode enabled - skipping point sampling for {self._attr_name}")
+                    # Update tracking variables and save, but don't add energy
+                    self._last_power = power
+                    self._last_update = now
+                    await self._save_state()
+                    self.safe_write_ha_state()
+                    return
                 # Point sampling fallback using trapezoidal rule
                 if self._last_power is not None and self._last_update is not None:
                     time_delta = (now - self._last_update).total_seconds()


### PR DESCRIPTION
- Incremented version number in manifest.json to 0.0.70.
- Added new configuration options: force_statistical_only and stat_initial_lookback_minutes for improved user control over statistical calculations.
- Updated options flow to incorporate the new configuration options, enhancing flexibility in sensor behavior.
- Refined statistical calculation logic to allow for a configurable initial lookback window and to enforce statistical-only mode.

These changes aim to provide users with greater customization and control over energy sensor behavior, improving the overall functionality of the integration.